### PR TITLE
Fix regexes for building new cask file

### DIFF
--- a/lib/update-casks.js
+++ b/lib/update-casks.js
@@ -179,10 +179,10 @@ const createPatch = async (app, branch, commitMessage) => {
     let caskFile = fs.readFileSync(filePath, 'utf8');
 
     caskFile = caskFile
-      .replace(/(url\s+['"]).+?(['"])/g, `$1${app.jetbrains.urlTemplate}$2`)
-      .replace(/(version\s+').+?(')/g, `$1${app.jetbrains.version}$2`)
-      .replace(/(appcast\s+').+?(',)/, `$1${app.cask.appcastGenerated}$2`)
-      .replace(/(sha256\s+').+?(')/g, `$1${app.jetbrains.sha256}$2`);
+      .replace(/(url\s+(['"])).+?(\2)/g, `$1${app.jetbrains.urlTemplate}$2`)
+      .replace(/(version\s+(['"])).+?(\2)/g, `$1${app.jetbrains.version}$2`)
+      .replace(/(appcast\s+(['"])).+?(\2,)/, `$1${app.cask.appcastGenerated}$2`)
+      .replace(/(sha256\s+(['"])).+?(\2)/g, `$1${app.jetbrains.sha256}$2`);
 
     fs.writeFileSync(filePath, caskFile);
 


### PR DESCRIPTION
Apparently homebrew-cask switched to `"` for quotes, this makes the regex a bit more stable.